### PR TITLE
issue  with invalid extract carrier.

### DIFF
--- a/opentracing/opentracing.go
+++ b/opentracing/opentracing.go
@@ -85,7 +85,7 @@ func (s *Span) Logger() tab.Logger {
 
 // Inject span context into carrier
 func (s *Span) Inject(carrier tab.Carrier) error {
-	return opentracing.GlobalTracer().Inject(s.span.Context(), opentracing.TextMap, carrierAdapter{carrier: carrier})
+	return opentracing.GlobalTracer().Inject(s.span.Context(), opentracing.TextMap, &carrierAdapter{carrier: carrier})
 }
 
 // InternalSpan returns the real implementation of the Span


### PR DESCRIPTION
var _ (opentracing.TextMapWriter) = (*carrierAdapter)(nil)
this will cause opentracing: Invalid Inject/Extract carrier when passed byval.