### PR TITLE
use annotation for logging, as they will not override eachothers

### DIFF
--- a/opencensus/go.mod
+++ b/opencensus/go.mod
@@ -1,8 +1,13 @@
 module github.com/devigned/tab/opencensus
 
+go 1.16
+
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/devigned/tab v0.0.1
+	github.com/stretchr/testify v1.7.0 // indirect
 	go.opencensus.io v0.21.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace github.com/devigned/tab => ../.

--- a/opencensus/go.sum
+++ b/opencensus/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -16,6 +18,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -23,6 +26,8 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
@@ -58,4 +63,7 @@ google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmE
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/opencensus/opencensus.go
+++ b/opencensus/opencensus.go
@@ -143,7 +143,7 @@ type AnnotationLogger struct {
 }
 
 func (a *AnnotationLogger) Info(msg string, attributes ...tab.Attribute) {
-	a.logToAnnotation("error", msg, attributes...)
+	a.logToAnnotation("info", msg, attributes...)
 }
 
 func (a *AnnotationLogger) Error(err error, attributes ...tab.Attribute) {

--- a/opencensus/opencensus_test.go
+++ b/opencensus/opencensus_test.go
@@ -1,0 +1,71 @@
+package opencensus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	oct "go.opencensus.io/trace"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testExporter struct {
+	SpanData  *oct.SpanData
+}
+
+func (t *testExporter) ExportSpan(s *oct.SpanData) {
+	t.SpanData = s
+}
+
+var _ oct.Exporter = &testExporter{}
+
+func TestAnnotationLoggerNoError(t *testing.T) {
+	exp := &testExporter{}
+	oct.RegisterExporter(exp)
+	_, s := oct.StartSpan(context.TODO(), "test no error", oct.WithSampler(oct.AlwaysSample()))
+
+	l := &AnnotationLogger{Span: &Span{
+		span : s,
+	}}
+	l.Info("info")
+	l.Debug("debug")
+	s.End()
+	assert.Len(t, exp.SpanData.Attributes,0)
+	assert.Equal(t, "info", exp.SpanData.Annotations[0].Message)
+	assert.Equal(t, "info", exp.SpanData.Annotations[0].Attributes["level"])
+	assert.Equal(t, "debug", exp.SpanData.Annotations[1].Message)
+	assert.Equal(t, "debug", exp.SpanData.Annotations[1].Attributes["level"])
+}
+
+func TestAnnotationLoggerWithError(t *testing.T) {
+	exp := &testExporter{}
+	oct.RegisterExporter(exp)
+	_, s := oct.StartSpan(context.TODO(), "test no error", oct.WithSampler(oct.AlwaysSample()))
+
+	l := &AnnotationLogger{Span: &Span{
+		span : s,
+	}}
+	l.Error(fmt.Errorf("error"))
+	s.End()
+	assert.Len(t, exp.SpanData.Attributes,1)
+	assert.Equal(t,true, exp.SpanData.Attributes["error"])
+	assert.Equal(t, "error", exp.SpanData.Annotations[0].Message)
+	assert.Equal(t, "error", exp.SpanData.Annotations[0].Attributes["level"])
+}
+
+func TestAnnotationLoggerWithFatal(t *testing.T) {
+	exp := &testExporter{}
+	oct.RegisterExporter(exp)
+	_, s := oct.StartSpan(context.TODO(), "test no error", oct.WithSampler(oct.AlwaysSample()))
+
+	l := &AnnotationLogger{Span: &Span{
+		span : s,
+	}}
+	l.Fatal("fatal")
+	s.End()
+	assert.Len(t, exp.SpanData.Attributes,1)
+	assert.Equal(t,true, exp.SpanData.Attributes["error"])
+	assert.Equal(t, "fatal", exp.SpanData.Annotations[0].Message)
+	assert.Equal(t, "fatal", exp.SpanData.Annotations[0].Attributes["level"])
+}


### PR DESCRIPTION
Using Span Attributes for span logs result in keeping only the last one, missing a timestamp.
Opencensus Annotations are timestamped, and will be appended in an array of annotations allowing to have proper span logs